### PR TITLE
Fix postgres service name in qvain.service

### DIFF
--- a/ansible/roles/provision_app/templates/qvain.service
+++ b/ansible/roles/provision_app/templates/qvain.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Qvain backend service
 #ConditionPathExists={{ app.base }}/bin/qvain-backend
-After=postgresql.service
-Wants=postgresql.service
-#Requires=postgresql.service
+After=postgresql-9.6.service
+Wants=postgresql-9.6.service
+#Requires=postgresql-9.6.service
 
 [Service]
 WorkingDirectory={{ app.base }}


### PR DESCRIPTION
The qvain.service file depends on non-existing postgresql.service instead of postgresql-9.6.service, which  can cause it to start too early on system boot. This fails both the database connection (since postgres isn't up yet) and OIDC discovery (because there's no network connection). 

