### PR TITLE
Frontend helper scripts

### DIFF
--- a/client-console.sh
+++ b/client-console.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+############################################################
+# This script allows easy startup of the frontend instance
+# for developer use.
+#
+# This file is part of Qvain project.
+#
+# Author(s):
+#     Juhapekka Piiroinen <juhapekka.piiroinen@csc.fi>
+#
+# Copyright 2019 CSC - IT Center for Science Ltd.
+# Copyright 2019 The National Library Of Finland
+# All Rights Reserved.
+############################################################
+screen -r qvain-js
+if [[ $? -ne 0 ]]; then
+  ./client-start.sh
+  ./client-console.sh
+fi

--- a/client-start.sh
+++ b/client-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+############################################################
+# This script allows easy startup of the frontend instance
+# for developer use.
+#
+# This file is part of Qvain project.
+#
+# Author(s):
+#     Juhapekka Piiroinen <juhapekka.piiroinen@csc.fi>
+#
+# Copyright 2019 CSC - IT Center for Science Ltd.
+# Copyright 2019 The National Library Of Finland
+# All Rights Reserved.
+############################################################
+screen -d -m -S qvain-js vagrant ssh -c 'sudo su - qvain -c "cd /qvain/qvain-js && npm run serve"'


### PR DESCRIPTION
Added client-console.sh and client-start.sh scripts.
    
These scripts will help the startup of the frontend development environment.
You can execute client-console.sh and it will launch the frontend development
server inside a screen session and it will attach to it.
    
If you just want to launch the frontend development server, then you can execute client-start.sh which will launch the server in detached screen session. If you then want to see the messages which appears in the screen, you can attach to the session using client-console.sh script.