### PR TITLE
CSCQVAIN-229: Added 'make check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all:
+
+check:
+	@cd tests && make check

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+chromedriver*
+venv

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,4 +18,5 @@ clean:
 	@rm -rf __pycache__
 
 check: venv chromedriver
+	@venv/bin/pycodestyle --show-source --show-pep8 .  --exclude=venv
 	@$(PYTHON_CMD) -m unittest discover

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,21 @@
+PYTHON_CMD:=source venv/bin/activate && python3
+
+all:
+
+venv:
+	python3 -m venv venv
+	source venv/bin/activate && pip3 install https://github.com/CSCfi/tauhka/archive/master.zip
+	source venv/bin/activate && pip3 install -r requirements.txt
+
+chromedriver:
+	curl -O https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_mac64.zip
+	unzip chromedriver_mac64.zip
+
+clean:
+	@rm -f chromedriver
+	@rm -f chromedriver_*.zip
+	@rm -rf venv
+	@rm -rf __pycache__
+
+check: venv chromedriver
+	@$(PYTHON_CMD) -m unittest discover

--- a/tests/qvainopstestcase.py
+++ b/tests/qvainopstestcase.py
@@ -16,7 +16,7 @@ import json
 import urllib3
 from tauhka.testcase import TauhkaTestCase
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
-
+from github import Github
 import warnings
 
 class QvainOPSTestCase(TauhkaTestCase):
@@ -32,6 +32,12 @@ class QvainOPSTestCase(TauhkaTestCase):
         # We do not have such xpath in our frontend
         assert self.elem_is_not_found_xpath(
             "/html/body/center[1]/h1"), "Frontend is not running"
+
+    def get_git_version(self):
+        g = Github()
+        frontend_version = g.get_repo("CSCfi/qvain-js").get_branch(branch="release").commit.sha
+        backend_version = g.get_repo("CSCfi/qvain-api").get_branch(branch="release").commit.sha
+        return (frontend_version, backend_version)
 
     def get_back_version(self):
         pool = urllib3.PoolManager()

--- a/tests/qvainopstestcase.py
+++ b/tests/qvainopstestcase.py
@@ -35,9 +35,17 @@ class QvainOPSTestCase(TauhkaTestCase):
 
     def get_git_version(self):
         g = Github()
-        frontend_version = g.get_repo("CSCfi/qvain-js").get_branch(branch="release").commit.sha
-        backend_version = g.get_repo("CSCfi/qvain-api").get_branch(branch="release").commit.sha
-        return (frontend_version, backend_version)
+        backend_repo = g.get_repo("CSCfi/qvain-api")
+        backend_hash = backend_repo.get_branch(branch="release").commit.sha
+        backend_tags = backend_repo.get_tags()
+        backend_tag = backend_tags[0].name
+
+        frontend_repo = g.get_repo("CSCfi/qvain-js")
+        frontend_hash = frontend_repo.get_branch(branch="release").commit.sha
+        frontend_tags = backend_repo.get_tags()
+        frontend_tag = frontend_tags[0].name
+
+        return (frontend_hash, frontend_tag), (backend_hash, backend_tag)
 
     def get_back_version(self):
         pool = urllib3.PoolManager()

--- a/tests/qvainopstestcase.py
+++ b/tests/qvainopstestcase.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+################################################################
+# This contains the base class QvainOPSTestCase with some helper
+# functions for tests.
+#
+# This file is part of Qvain project.
+#
+# Author(s):
+#     Juhapekka Piiroinen <juhapekka.piiroinen@csc.fi>
+#
+# Copyright (c) 2019 CSC - IT Center for Science Ltd.
+# All Rights Reserved.
+################################################################
+import os
+import json
+import urllib3
+from tauhka.testcase import TauhkaTestCase
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
+
+import warnings
+
+class QvainOPSTestCase(TauhkaTestCase):
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+        self.server = os.environ.get(
+            "TEST_ADDRESS",
+            "https://qvain.fairdata.fi"
+        )
+         
+    def is_frontend_running(self):
+        # This is the xpath for default error page header in nginx
+        # We do not have such xpath in our frontend
+        assert self.elem_is_not_found_xpath(
+            "/html/body/center[1]/h1"), "Frontend is not running"
+
+    def get_back_version(self):
+        pool = urllib3.PoolManager()
+        warnings.simplefilter("ignore", ResourceWarning)
+
+        version_raw = pool.request(
+            'GET', "{address}/api/version".format(
+                address=self.server
+            )
+        ).data
+        version_info = json.loads(version_raw)
+        return (version_info["hash"],version_info["version"])
+
+    def get_front_version(self):
+        self.open_url(
+            "{address}/config".format(
+                address=self.server
+            )
+        )
+        self.is_frontend_running()
+        self.wait_until_window_title("Qvain")
+        commit_hash = self.find_element_by_xpath('//*[@id="app-body"]/div/div/div/dl/dd[5]/code').text
+        version = self.find_element_by_xpath('//*[@id="app-body"]/div/div/div/dl/dd[4]/code').text
+        return (commit_hash, version)
+        

--- a/tests/qvainopstestcase.py
+++ b/tests/qvainopstestcase.py
@@ -27,6 +27,7 @@ class QvainOPSTestCase(TauhkaTestCase):
             "TEST_ADDRESS",
             "https://qvain.fairdata.fi"
         )
+        self.branch = os.environ.get("GITHUB_BRANCH", "release")
          
     def is_frontend_running(self):
         # This is the xpath for default error page header in nginx
@@ -47,12 +48,12 @@ class QvainOPSTestCase(TauhkaTestCase):
             else:
                 g = Github()
             backend_repo = g.get_repo("CSCfi/qvain-api")
-            backend_hash = backend_repo.get_branch(branch="release").commit.sha
+            backend_hash = backend_repo.get_branch(branch=self.branch).commit.sha
             backend_tags = backend_repo.get_tags()
             backend_tag = backend_tags[0].name
 
             frontend_repo = g.get_repo("CSCfi/qvain-js")
-            frontend_hash = frontend_repo.get_branch(branch="release").commit.sha
+            frontend_hash = frontend_repo.get_branch(branch=self.branch).commit.sha
             frontend_tags = backend_repo.get_tags()
             frontend_tag = frontend_tags[0].name
 

--- a/tests/qvainopstestcase.py
+++ b/tests/qvainopstestcase.py
@@ -20,6 +20,7 @@ from github import Github
 from github.GithubException import RateLimitExceededException
 import warnings
 
+
 class QvainOPSTestCase(TauhkaTestCase):
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
@@ -28,7 +29,7 @@ class QvainOPSTestCase(TauhkaTestCase):
             "https://qvain.fairdata.fi"
         )
         self.branch = os.environ.get("GITHUB_BRANCH", "release")
-         
+
     def is_frontend_running(self):
         # This is the xpath for default error page header in nginx
         # We do not have such xpath in our frontend
@@ -59,7 +60,7 @@ class QvainOPSTestCase(TauhkaTestCase):
 
             return (frontend_hash, frontend_tag), (backend_hash, backend_tag)
         except RateLimitExceededException:
-            return ("GITHUB_RATE_LIMIT",""),("","")
+            return ("GITHUB_RATE_LIMIT", ""), ("", "")
 
     def get_back_version(self):
         pool = urllib3.PoolManager()
@@ -71,7 +72,7 @@ class QvainOPSTestCase(TauhkaTestCase):
             )
         ).data
         version_info = json.loads(version_raw)
-        return (version_info["hash"],version_info["version"])
+        return (version_info["hash"], version_info["version"])
 
     def get_front_version(self):
         self.open_url(
@@ -84,4 +85,3 @@ class QvainOPSTestCase(TauhkaTestCase):
         commit_hash = self.find_element_by_xpath('//*[@id="app-body"]/div/div/div/dl/dd[5]/code').text
         version = self.find_element_by_xpath('//*[@id="app-body"]/div/div/div/dl/dd[4]/code').text
         return (commit_hash, version)
-        

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+PyGithub

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 PyGithub
+pycodestyle

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -18,24 +18,37 @@ class QvainVersion(QvainOPSTestCase):
     def test_version(self):
         front_version = self.get_front_version()
         back_version = self.get_back_version()
-
-        print("Server: {address}".format(
+        git_version = self.get_git_version()
+        print()
+        print("Server:\t{address}".format(
             address=self.server
         ))
-        print("Time: {timestamp}".format(
+        print("Time:\t{timestamp}".format(
             timestamp=datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         ))
+        print()
+        print("=== Available @ Github ===")
+        print("Front:\t{commit_hash}".format(
+            commit_hash=git_version[0],
+        ))
+        print("Back:\t{commit_hash}".format(
+            commit_hash=git_version[1],
+        ))  
 
-        print("JS version: {version} ({commit_hash})".format(
+        print()
+        print("=== Installed @ Server ===")
+        print("Front:\t{version} ({commit_hash})".format(
             commit_hash=front_version[0],
             version=front_version[1]
         ))
 
-        print("API version: {version} ({commit_hash})".format(
+        print("Back:\t{version} ({commit_hash})".format(
             commit_hash=back_version[0],
             version=back_version[1]
         ))        
         assert front_version[1] == back_version[1], "Front and Back-end should be running the same version"
+        print()
+
 
     def end_test(self):
         pass

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+################################################################
+# This test can be used to get the information of the current
+# version which is running on the target address.
+#
+# This file is part of Qvain project.
+#
+# Author(s):
+#     Juhapekka Piiroinen <juhapekka.piiroinen@csc.fi>
+#
+# Copyright (c) 2019 CSC - IT Center for Science Ltd.
+# All Rights Reserved.
+################################################################
+from qvainopstestcase import QvainOPSTestCase
+import datetime
+
+class QvainVersion(QvainOPSTestCase):
+    def test_version(self):
+        front_version = self.get_front_version()
+        back_version = self.get_back_version()
+
+        print("Server: {address}".format(
+            address=self.server
+        ))
+        print("Time: {timestamp}".format(
+            timestamp=datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        ))
+
+        print("JS version: {version} ({commit_hash})".format(
+            commit_hash=front_version[0],
+            version=front_version[1]
+        ))
+
+        print("API version: {version} ({commit_hash})".format(
+            commit_hash=back_version[0],
+            version=back_version[1]
+        ))        
+        assert front_version[1] == back_version[1], "Front and Back-end should be running the same version"
+
+    def end_test(self):
+        pass

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -28,21 +28,23 @@ class QvainVersion(QvainOPSTestCase):
         ))
         print()
         print("=== Available @ Github ===")
-        print("Front:\t{commit_hash}".format(
-            commit_hash=git_version[0],
+        print("Front:\t{tag_name}\t{commit_hash}".format(
+            commit_hash=git_version[0][0],
+            tag_name=git_version[0][1],
         ))
-        print("Back:\t{commit_hash}".format(
-            commit_hash=git_version[1],
+        print("Back:\t{tag_name}\t{commit_hash}".format(
+            commit_hash=git_version[1][0],
+            tag_name=git_version[1][1],
         ))  
 
         print()
         print("=== Installed @ Server ===")
-        print("Front:\t{version} ({commit_hash})".format(
+        print("Front:\t{version}\t{commit_hash}".format(
             commit_hash=front_version[0],
             version=front_version[1]
         ))
 
-        print("Back:\t{version} ({commit_hash})".format(
+        print("Back:\t{version}\t{commit_hash}".format(
             commit_hash=back_version[0],
             version=back_version[1]
         ))        

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -27,7 +27,7 @@ class QvainVersion(QvainOPSTestCase):
             timestamp=datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         ))
         print()
-        print("=== Available @ Github ===")
+        print("=== Available @ Github ({branch}) ===".format(branch=self.branch))
         print("Front:\t{tag_name}\t{commit_hash}".format(
             commit_hash=git_version[0][0],
             tag_name=git_version[0][1],

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -14,6 +14,7 @@
 from qvainopstestcase import QvainOPSTestCase
 import datetime
 
+
 class QvainVersion(QvainOPSTestCase):
     def test_version(self):
         front_version = self.get_front_version()
@@ -35,7 +36,7 @@ class QvainVersion(QvainOPSTestCase):
         print("Back:\t{tag_name}\t{commit_hash}".format(
             commit_hash=git_version[1][0],
             tag_name=git_version[1][1],
-        ))  
+        ))
 
         print()
         print("=== Installed @ Server ===")
@@ -47,10 +48,9 @@ class QvainVersion(QvainOPSTestCase):
         print("Back:\t{version}\t{commit_hash}".format(
             commit_hash=back_version[0],
             version=back_version[1]
-        ))        
+        ))
         assert front_version[1] == back_version[1], "Front and Back-end should be running the same version"
         print()
-
 
     def end_test(self):
         pass

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,0 +1,4 @@
+[pycodestyle]
+count = False
+max-line-length = 160
+statistics = True


### PR DESCRIPTION
This allows a manual verification step for a deployment, when it is
executed prior and after the deployment from the local
machine.

Will fetch the installation information (version and commit hash) from
both front and back-end side.

```
$ make check

Server:	https://qvain.fairdata.fi
Time:	2019-06-27 15:55:38

=== Available @ Github (release) ===
Front:	v0.10.0	3b318572c93169170d886cfe6330c7357a37bf3e
Back:	v0.10.0	259a450d0b401185b916dc0f3ebc23b1f2b4295a

=== Installed @ Server ===
Front:	0.10.0	3b318572c93169170d886cfe6330c7357a37bf3e
Back:	0.10.0	259a450

.
----------------------------------------------------------------------
Ran 1 test in 14.104s

OK
```

Supports following environment variables:
**GITHUB_USERNAME** When this and GITHUB_PASSWORD are defined then those are used for auth.
**GITHUB_PASSWORD** see GITHUB_USERNAME
**GITHUB_ACCESS_TOKEN** When this is defined and GITHUB_PASSWORD and GITHUB_USERNAME are not then this is used for auth.
**GITHUB_BRANCH** The branch which is checked from Github, default is release.
**TEST_ADDRESS** The server address, default is https://qvain.fairdata.fi