### PR TITLE
Fixed builds to allow qvain-test upgrade

### DIFF
--- a/ansible/roles/webapp/tasks/main.yml
+++ b/ansible/roles/webapp/tasks/main.yml
@@ -42,6 +42,8 @@
     repo: "{{ app.webrepo }}"
     dest: "{{ tmp_webapp.path }}"
     version: "{{ app.branch }}"
+    update: yes
+    force: yes
   become_user: "{{ app.user }}"
   when: app.webrepo is defined
 


### PR DESCRIPTION
The provisioning fails when upgrading qvain-test environment without those flags.