### PR TITLE
CSCQVAIN-485: Fixed node version to 10.x series.

### DIFF
--- a/ansible/roles/nodejs/tasks/main.yml
+++ b/ansible/roles/nodejs/tasks/main.yml
@@ -9,8 +9,8 @@
   args:
     creates: "/home/{{ app.user }}/.nvm/nvm.sh"
 
-- name: Install latest node LTS version using nvm
-  shell: "cd; source .bashrc; nvm install --lts"
+- name: Install latest node 10.x LTS version using nvm
+  shell: "cd; source .bashrc; nvm install --lts=dubnium"
   become_user: "{{ app.user }}"
   args:
     executable: /bin/bash


### PR DESCRIPTION
It looks like that the --lts was changed from 10.x series to 12.x with nvm.
https://github.com/nodejs/Release#release-schedule