### PR TITLE
CSCQVAIN-485: set default nodejs to 10.x.

### DIFF
--- a/ansible/roles/local_build/tasks/node.yml
+++ b/ansible/roles/local_build/tasks/node.yml
@@ -9,3 +9,9 @@
   shell: "cd; source .nvm/nvm.sh; nvm install --lts"
   args:
     executable: /bin/bash
+
+- name: Use nodeJS 10.x series
+  shell: "cd; source .bashrc; nvm use 10"
+  become_user: "{{ app.user }}"
+  args:
+    executable: /bin/bash

--- a/ansible/roles/nodejs/tasks/main.yml
+++ b/ansible/roles/nodejs/tasks/main.yml
@@ -14,3 +14,9 @@
   become_user: "{{ app.user }}"
   args:
     executable: /bin/bash
+
+- name: Use nodeJS 10.x series
+  shell: "cd; source .bashrc; nvm use 10"
+  become_user: "{{ app.user }}"
+  args:
+    executable: /bin/bash


### PR DESCRIPTION
We need to call `nvm use 10` to ensure that the nodejs 10.x is selected, as it can be that there is a newer installed and that is default.