### PR TITLE
CSCQVAIN-485: the default alias is broken with nvm.

### DIFF
--- a/ansible/roles/local_build/tasks/node.yml
+++ b/ansible/roles/local_build/tasks/node.yml
@@ -6,11 +6,11 @@
     creates: "{{ ansible_env.HOME }}/.nvm/nvm.sh"
 
 - name: Install latest node LTS version using nvm
-  shell: "cd; source .nvm/nvm.sh; nvm install --lts"
+  shell: "cd; source .nvm/nvm.sh; nvm install --lts=dubnium"
   args:
     executable: /bin/bash
 
 - name: Use nodeJS 10.x series
-  shell: "cd; source .nvm/nvm.sh; nvm use 10"
+  shell: "cd; source .nvm/nvm.sh; nvm alias default lts/dubnium"
   args:
     executable: /bin/bash

--- a/ansible/roles/nodejs/tasks/main.yml
+++ b/ansible/roles/nodejs/tasks/main.yml
@@ -16,7 +16,7 @@
     executable: /bin/bash
 
 - name: Use nodeJS 10.x series
-  shell: "cd; source .bashrc; nvm use 10"
+  shell: "cd; source .bashrc; nvm alias default lts/dubnium"
   become_user: "{{ app.user }}"
   args:
     executable: /bin/bash


### PR DESCRIPTION
It must be called in order to have it up and running.