### PR TITLE
CSCFAIRMETA-266: Fixed nginx configuration.

### DIFF
--- a/ansible/roles/nginx/templates/nginx.conf
+++ b/ansible/roles/nginx/templates/nginx.conf
@@ -56,7 +56,9 @@ http {
 		# this will load letsencrypt configuration if it exists
 		include /etc/nginx/default.d/*.conf;
 
-		return 301 https://$server_name$request_uri;
+		location / {
+			return 301 https://$server_name$request_uri;
+		}
 	}
 
 	upstream app {


### PR DESCRIPTION
This will fix the broken lets encrypt renewal.