### PR TITLE
CSCFAIRMETA-291: Increase nginx proxy timeout

### DIFF
--- a/ansible/roles/nginx/templates/nginx.conf
+++ b/ansible/roles/nginx/templates/nginx.conf
@@ -152,10 +152,6 @@ http {
 			proxy_http_version 1.1;
 			proxy_set_header Connection "";
 
-			# set timeouts
-			proxy_connect_timeout 15s;
-			proxy_read_timeout 15s;
-
 			# turn off buffering of requests and responses; let the Go HTTP server handle that (requires proxy_http_version to be set to 1.1)
 			proxy_request_buffering off;
 			proxy_buffering off;

--- a/ansible/roles/nginx/templates/nginx.conf
+++ b/ansible/roles/nginx/templates/nginx.conf
@@ -152,9 +152,9 @@ http {
 			proxy_http_version 1.1;
 			proxy_set_header Connection "";
 
-			# lower timeouts
-			proxy_connect_timeout 5s;
-			proxy_read_timeout 5s;
+			# set timeouts
+			proxy_connect_timeout 15s;
+			proxy_read_timeout 15s;
 
 			# turn off buffering of requests and responses; let the Go HTTP server handle that (requires proxy_http_version to be set to 1.1)
 			proxy_request_buffering off;


### PR DESCRIPTION
If Metax responds too slowly, the request from frontend to backend may time out even if the action (e.g. publish) succeeds. As a result, the frontend thinks that the action failed. This should make it less likely to happen.