### PR TITLE
Fix broken postgresql download link

### DIFF
--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -2,7 +2,7 @@
   file: path=/etc/pki/selfsigned state=directory recurse=yes
 
 - name: Create dummy self-signed certificate
-  command: "openssl req -x509 -nodes -subj '/C=FI/ST=Uusimaa/L=Espoo/O=CSC - Tieteen tietotekniikan keskus Oy/CN={{ server.fqdn }}' -addext 'subjectAltName = DNS:{{ server.fqdn }}' -addext 'extendedKeyUsage = serverAuth' -days 365 -newkey rsa:2048 -keyout /etc/pki/selfsigned/{{ server.hostname }}.key -out /etc/pki/selfsigned/{{ server.hostname }}.crt"
+  command: "openssl req -x509 -nodes -subj '/C=FI/ST=Uusimaa/L=Espoo/O=CSC - Tieteen tietotekniikan keskus Oy/CN={{ server.fqdn }}' -days 365 -newkey rsa:2048 -keyout /etc/pki/selfsigned/{{ server.hostname }}.key -out /etc/pki/selfsigned/{{ server.hostname }}.crt"
   args:
     creates: /etc/pki/selfsigned/{{ server.hostname }}.crt
 

--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -2,7 +2,7 @@
   file: path=/etc/pki/selfsigned state=directory recurse=yes
 
 - name: Create dummy self-signed certificate
-  command: "openssl req -x509 -nodes -subj '/C=FI/ST=Uusimaa/L=Espoo/O=CSC - Tieteen tietotekniikan keskus Oy/CN={{ server.fqdn }}' -days 365 -newkey rsa:2048 -keyout /etc/pki/selfsigned/{{ server.hostname }}.key -out /etc/pki/selfsigned/{{ server.hostname }}.crt"
+  command: "openssl req -x509 -nodes -subj '/C=FI/ST=Uusimaa/L=Espoo/O=CSC - Tieteen tietotekniikan keskus Oy/CN={{ server.fqdn }}' -addext 'subjectAltName = DNS:{{ server.fqdn }}' -addext 'extendedKeyUsage = serverAuth' -days 365 -newkey rsa:2048 -keyout /etc/pki/selfsigned/{{ server.hostname }}.key -out /etc/pki/selfsigned/{{ server.hostname }}.crt"
   args:
     creates: /etc/pki/selfsigned/{{ server.hostname }}.crt
 

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -9,7 +9,7 @@
 #    state: present
 
 - name: Install Postgresql yum repository package
-  yum: name=https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/pgdg-centos96-9.6-3.noarch.rpm state=present
+  yum: name=https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm state=present
   when: deployment_environment_id != 'production'
 
 - name: Install PostgreSQL 9 and python psycopg2


### PR DESCRIPTION
- Fix broken postgresql download link
- The new link should be functional

Another thing learned:

The OpenSSL flag -addext is used in the qvain-ops ansible setup, but does not work on macOS (though should work on Linux).

Source: https://developer.apple.com/forums/thread/119877